### PR TITLE
update configure flags to enable -fPIC and AVX

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -35,7 +35,7 @@ TEST_CMD="eval cd tests && ${LIBRARY_SEARCH_VAR}=\"$PREFIX/lib\" make check-loca
 #
 
 # (1) Single precision (fftw libraries have "f" suffix)
-$CONFIGURE --enable-float --enable-sse
+$CONFIGURE --enable-float --enable-sse2 --enable-avx
 ${BUILD_CMD}
 ${INSTALL_CMD}
 ${TEST_CMD}
@@ -47,7 +47,7 @@ ${INSTALL_CMD}
 ${TEST_CMD}
 
 # (3) Double precision (fftw libraries have no precision suffix)
-$CONFIGURE --enable-sse2
+$CONFIGURE --enable-sse2 --enable-avx
 ${BUILD_CMD}
 ${INSTALL_CMD}
 ${TEST_CMD}

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -33,24 +33,23 @@ TEST_CMD="eval cd tests && ${LIBRARY_SEARCH_VAR}=\"$PREFIX/lib\" make check-loca
 #
 # We build 3 different versions of fftw:
 #
+build_cases=(
+    # single
+    "$CONFIGURE --enable-float --enable-sse2 --enable-avx"
+    # double
+    "$CONFIGURE --enable-sse2 --enable-avx"
+    # long double (SSE2 and AVX not supported)
+    "$CONFIGURE --enable-long-double"
+)
 
-# (1) Single precision (fftw libraries have "f" suffix)
-$CONFIGURE --enable-float --enable-sse2 --enable-avx
-${BUILD_CMD}
-${INSTALL_CMD}
-${TEST_CMD}
-
-# (2) Long double precision (fftw libraries have "l" suffix)
-$CONFIGURE --enable-long-double
-${BUILD_CMD}
-${INSTALL_CMD}
-${TEST_CMD}
-
-# (3) Double precision (fftw libraries have no precision suffix)
-$CONFIGURE --enable-sse2 --enable-avx
-${BUILD_CMD}
-${INSTALL_CMD}
-${TEST_CMD}
+for config in "${build_cases[@]}"
+do
+    :
+    $config
+    ${BUILD_CMD}
+    ${INSTALL_CMD}
+    ${TEST_CMD}
+done
 
 unset LIBRARY_SEARCH_VAR
 unset DYLIB_EXT

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -35,7 +35,7 @@ TEST_CMD="eval cd tests && ${LIBRARY_SEARCH_VAR}=\"$PREFIX/lib\" make check-loca
 #
 build_cases=(
     # single
-    "$CONFIGURE --enable-float --enable-sse2 --enable-avx"
+    "$CONFIGURE --enable-float --enable-sse --enable-sse2 --enable-avx"
     # double
     "$CONFIGURE --enable-sse2 --enable-avx"
     # long double (SSE2 and AVX not supported)

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -18,7 +18,7 @@ fi
 export LDFLAGS="-L${PREFIX}/lib"
 export CFLAGS="${CFLAGS} -I${PREFIX}/include"
 
-CONFIGURE="./configure --prefix=$PREFIX --enable-shared --enable-threads --disable-fortran"
+CONFIGURE="./configure --prefix=$PREFIX --with-pic --enable-shared --enable-threads --disable-fortran"
 
 # (Note exported LDFLAGS and CFLAGS vars provided above.)
 BUILD_CMD="make -j${CPU_COUNT}"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
 
 build:
     skip: True  # [win]
-    number: 2
+    number: 3
 
 test:
     commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,3 +31,4 @@ extra:
         - alexbw
         - jakirkham
         - jjhelmus
+        - grlee77


### PR DESCRIPTION
I propose to add the `--with-pic` flag to `./configure` so that it will then be possible to build a version of pyFFTW that statically links to the FFTW libraries built here.  Currently when both MKL and pyFFTW are installed there is a problem where MKL FFT routines get dynamically linked instead of the desired FFTW ones.  This occurs, for instance, whenever numpy is imported prior to pyFFTW.  This has been causing a lot of pains for myself and others as discussed in the following places:
pyFFTW/pyFFTW#40
pyFFTW/pyFFTW#106
https://groups.google.com/a/continuum.io/forum/#!topic/anaconda/zXT3dRsKK10
It wouldn't be so bad except that the MKL routines only support a subset of the FFTW functionality.

I have created a version of the pyFFTW feedstock that resolves the issues above (if built against FFTW using the `--with-pic` flag):
https://github.com/grlee77/pyfftw-feedstock/tree/static_link
This is currently being done by patching setup.py to enable linking to the static libraries.

The second commit here just adds `--enable-avx` during configure to improve performance on machines that support AVX.  According the FFTW docs this does not **require** machines to have AVX, only that the compiler supports it at build time.
