### PR TITLE
Add `perl` as a build dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,12 @@ build:
     skip: True  # [win]
     number: 3
 
+requirements:
+    build:
+        # Pin perl to workaround a conda-build issue where it assumes
+        # a very specific version of perl (i.e. 5.18.2).
+        - perl >=5.20
+
 test:
     commands:
         - exit $(test -f ${PREFIX}/lib/libfftw3f.a)          # [not win]


### PR DESCRIPTION
As we switched from `git` provided by `yum` to the `conda-forge` one, we find that there is no `perl` on the path. It turns out that `fftw`'s `make check-local` was using `perl` and so was implicitly dependent on the system `perl`. Now we need to add `perl` explicitly to fix this problem.

cc @grlee77