### PR TITLE
Correctly deal with perl, and rerender.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@
 language: objective-c
 
 env:
+  matrix:
+    
+    - CONDA_PERL=5.20.3.1
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "FPpNAvIcSlLlyLjrFAQXs1ubfz33/uLQ7FMCXvWRc3MXbgxD+WyHU+BVjkX6uu5GOqKnqFc9H8PCyctMNWS21h2ZRRth7chptwYU6R7AyEWg9gcCZW8vEgu06hGnvTtza7K/EwGPxG3MuAJixkwf5Wawl2lrc6mhLQkMXBQhBv+mpZvTqD6rmD/qd3FtZpFswor3hW1ZfenWWEpKAmqGinJsgwPnUPLvXHc038VmYb1jbK5iN2y2uCIvr+3Gp1/zilzkOshxsjb8flezSAMeTH3lkFJ+g99viN24GaJZOjxDLzUssRudxXmrzUlFtX+VCcTBTLtEO3OVSL7TtjD/HzXxin29FIk1vOZVr2RmvzVT7uHPYvOX+gLBBGPcUyooAg6KiOIIp9pvAOK3L1JTjIWRcpDhPMZouDloF2HUXEcZ6nYpNZJVVAHJZTK4AHGcL3VFOWGQjmcU63EtPuFPhJRP4yjTGincbeQEtwBo1gIH2PiFQhLNyYs4dRXFMP411qdSE6ncQGdhlCtkUw/T4rc4+bl63NW5qxQhksjCyD8tajW4Qj0+TnDmPFk4F7lczn/SwfoIJGH6YLaTmlTRqlYgM8L0R2jA5HQPsGhlvvHgfLw/k4ijHkBXe4aumvo1fcaqUyVVEhcdHRz1WYLp6fmEYURET2F6m8s5l6Z8Eqo="

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -44,6 +44,9 @@ conda install --yes conda-build
 conda info
 
 # Embarking on 1 case(s).
+    set -x
+    export CONDA_PERL=5.20.3.1
+    set +x
     conda build /recipe_root --quiet || exit 1
     /feedstock_root/ci_support/upload_or_check_non_existence.py /recipe_root conda-forge --channel=main || exit 1
 EOF

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,9 +13,7 @@ build:
 
 requirements:
     build:
-        # Pin perl to workaround a conda-build issue where it assumes
-        # a very specific version of perl (i.e. 5.18.2).
-        - perl >=5.20
+        - perl
 
 test:
     commands:


### PR DESCRIPTION
Different to most of our other pinning because conda-build treats Perl in a special way (i.e. it has a `CONDA_PERL` environment variable).