### PR TITLE
Add -O3 flag for performance.

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
-export CFLAGS="${CFLAGS} -I${PREFIX}/include -O3 -fomit-frame-pointer -malign-double -fstrict-aliasing -ffast-math"
+export CFLAGS="${CFLAGS} -I${PREFIX}/include -O3 -fomit-frame-pointer -fstrict-aliasing -ffast-math"
 
 CONFIGURE="./configure --prefix=$PREFIX --with-pic --enable-shared --enable-threads --disable-fortran"
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
-export CFLAGS="${CFLAGS} -I${PREFIX}/include -O3"
+export CFLAGS="${CFLAGS} -I${PREFIX}/include -O3 -fomit-frame-pointer -malign-double -fstrict-aliasing -ffast-math"
 
 CONFIGURE="./configure --prefix=$PREFIX --with-pic --enable-shared --enable-threads --disable-fortran"
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
-export CFLAGS="${CFLAGS} -I${PREFIX}/include"
+export CFLAGS="${CFLAGS} -I${PREFIX}/include -O3"
 
 CONFIGURE="./configure --prefix=$PREFIX --with-pic --enable-shared --enable-threads --disable-fortran"
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: a5de35c5c824a78a058ca54278c706cdf3d4abba1c56b63531c2cb05f5d57da2
 
 build:
-  number: 2
+  number: 3
   features:
     - vc9  # [win and py27]
     - vc14  # [win and py>=35]


### PR DESCRIPTION
On my test systems this makes single-threaded FFTs via pyFFTW ~5 times faster than they are with the current recipe.  Without any optimization flags, performance is slower than `numpy.fft`.

Thanks to @sambarluc for bringing this to my attention.  More info/benchmarks in pyFFTW/pyFFTW#184
