### PR TITLE
Add Fortran support on Linux and macOS

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,7 +26,7 @@ install:
     # If there is a newer build queued for the same PR, cancel this one.
     - cmd: |
         powershell -Command "(New-Object Net.WebClient).DownloadFile('https://raw.githubusercontent.com/conda-forge/conda-forge-ci-setup-feedstock/master/recipe/conda_forge_ci_setup/ff_ci_pr_build.py', 'ff_ci_pr_build.py')"
-        ff_ci_pr_build -v --ci "appveyor" "%APPVEYOR_ACCOUNT_NAME%/%APPVEYOR_PROJECT_SLUG%" "%APPVEYOR_BUILD_NUMBER%" "%APPVEYOR_PULL_REQUEST_NUMBER%"
+        "%CONDA_INSTALL_LOCN%\python.exe" ff_ci_pr_build.py -v --ci "appveyor" "%APPVEYOR_ACCOUNT_NAME%/%APPVEYOR_PROJECT_SLUG%" "%APPVEYOR_BUILD_NUMBER%" "%APPVEYOR_PULL_REQUEST_NUMBER%"
         del ff_ci_pr_build.py
 
     # Cygwin's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -22,7 +22,7 @@ jobs:
   # configure qemu binfmt-misc running.  This allows us to run docker containers 
   # embedded qemu-static
   - script: |
-      docker run --rm --privileged multiarch/qemu-user-static:register
+      docker run --rm --privileged multiarch/qemu-user-static:register --reset --credential yes
       ls /proc/sys/fs/binfmt_misc/
     condition: not(startsWith(variables['CONFIG'], 'linux_64'))
     displayName: Configure binfmt_misc

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -77,6 +77,11 @@ jobs:
       displayName: conda-forge build setup
     
 
+    - script: |
+        rmdir C:\strawberry /s /q
+      continueOnError: true
+      displayName: remove strawberryperl
+
     # Special cased version setting some more things!
     - script: |
         conda.exe build recipe -m .ci_support\%CONFIG%.yaml

--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -6,6 +6,8 @@ channel_targets:
 - conda-forge main
 docker_image:
 - condaforge/linux-anvil-comp7
+fortran_compiler:
+- gfortran
 perl:
 - '5.26'
 pin_run_as_build:

--- a/.ci_support/osx_.yaml
+++ b/.ci_support/osx_.yaml
@@ -6,6 +6,10 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '4'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Feedstock Maintainers
 
 * [@alexbw](https://github.com/alexbw/)
 * [@beckermr](https://github.com/beckermr/)
+* [@egpbos](https://github.com/egpbos/)
 * [@grlee77](https://github.com/grlee77/)
 * [@jakirkham](https://github.com/jakirkham/)
 * [@jjhelmus](https://github.com/jjhelmus/)

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,7 +3,7 @@
 export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
 export CFLAGS="${CFLAGS} -I${PREFIX}/include -O3 -fomit-frame-pointer -fstrict-aliasing -ffast-math"
 
-CONFIGURE="./configure --prefix=$PREFIX --with-pic --enable-shared --enable-threads --disable-fortran"
+CONFIGURE="./configure --prefix=$PREFIX --with-pic --enable-shared --enable-threads"
 
 if [[ `uname` == Darwin ]] && [[ "$CC" != "clang" ]]
 then

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,13 +10,14 @@ source:
   sha256: 6113262f6e92c5bd474f2875fa1b01054c4ad5040f6b0da7c03c98821d9ae303
 
 build:
-  number: 1002
+  number: 1003
 
 requirements:
   build:
     - perl   # [not win]
     - cmake  # [win]
     - {{ compiler('c') }}
+    - {{ compiler('fortran') }}  # [not win]
   host:
     - llvm-openmp >=4.0.1  # [osx]
   run:
@@ -24,6 +25,10 @@ requirements:
 
 test:
   commands:
+    # Verify library contains Fortran symbols
+    - |                                                  # [not win]
+      strings ${PREFIX}/lib/libfftw3.a | grep -q dfftw   # [not win]
+    # Verify existence of library files
     - exit $(test -f ${PREFIX}/lib/libfftw3f.a)          # [not win]
     - exit $(test -f ${PREFIX}/lib/libfftw3.a)           # [not win]
     - exit $(test -f ${PREFIX}/lib/libfftw3l.a)          # [not win]
@@ -82,3 +87,4 @@ extra:
     - grlee77
     - jschueller
     - beckermr
+    - egpbos


### PR DESCRIPTION
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Fixes #16 

This PR supersedes #42, but contains essentially the same addition: in Linux and macOS the Fortran build is enabled. On Windows it should fail to detect the Fortran compiler at configuration time and thus automatically disable Fortran support there. In #42 `flang` was added as the Fortran compiler on Windows, but I don't know what's the status of `flang` (@isuruf?) and whether a decision has since been made to use it in this feedstock or not.