### PR TITLE
Unpin llvm-openmp to allow conda-forge-pinning to take over

### DIFF
--- a/.ci_support/osx_64_mpimpichpython3.6.____cpython.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.6.____cpython.yaml
@@ -12,6 +12,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '9'
+llvm_openmp:
+- '11'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpimpichpython3.7.____cpython.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.7.____cpython.yaml
@@ -12,6 +12,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '9'
+llvm_openmp:
+- '11'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpimpichpython3.8.____cpython.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.8.____cpython.yaml
@@ -12,6 +12,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '9'
+llvm_openmp:
+- '11'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpimpichpython3.9.____cpython.yaml
+++ b/.ci_support/osx_64_mpimpichpython3.9.____cpython.yaml
@@ -12,6 +12,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '9'
+llvm_openmp:
+- '11'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpinompipython3.6.____cpython.yaml
+++ b/.ci_support/osx_64_mpinompipython3.6.____cpython.yaml
@@ -12,6 +12,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '9'
+llvm_openmp:
+- '11'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpinompipython3.7.____cpython.yaml
+++ b/.ci_support/osx_64_mpinompipython3.7.____cpython.yaml
@@ -12,6 +12,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '9'
+llvm_openmp:
+- '11'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpinompipython3.8.____cpython.yaml
+++ b/.ci_support/osx_64_mpinompipython3.8.____cpython.yaml
@@ -12,6 +12,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '9'
+llvm_openmp:
+- '11'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpinompipython3.9.____cpython.yaml
+++ b/.ci_support/osx_64_mpinompipython3.9.____cpython.yaml
@@ -12,6 +12,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '9'
+llvm_openmp:
+- '11'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpiopenmpipython3.6.____cpython.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.6.____cpython.yaml
@@ -12,6 +12,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '9'
+llvm_openmp:
+- '11'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpiopenmpipython3.7.____cpython.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.7.____cpython.yaml
@@ -12,6 +12,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '9'
+llvm_openmp:
+- '11'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpiopenmpipython3.8.____cpython.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.8.____cpython.yaml
@@ -12,6 +12,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '9'
+llvm_openmp:
+- '11'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_64_mpiopenmpipython3.9.____cpython.yaml
+++ b/.ci_support/osx_64_mpiopenmpipython3.9.____cpython.yaml
@@ -12,6 +12,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '9'
+llvm_openmp:
+- '11'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 mpi:

--- a/.ci_support/osx_arm64_mpimpichpython3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.8.____cpython.yaml
@@ -12,6 +12,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '11'
+llvm_openmp:
+- '11'
 macos_machine:
 - arm64-apple-darwin20.0.0
 mpi:

--- a/.ci_support/osx_arm64_mpimpichpython3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpimpichpython3.9.____cpython.yaml
@@ -12,6 +12,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '11'
+llvm_openmp:
+- '11'
 macos_machine:
 - arm64-apple-darwin20.0.0
 mpi:

--- a/.ci_support/osx_arm64_mpinompipython3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpinompipython3.8.____cpython.yaml
@@ -12,6 +12,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '11'
+llvm_openmp:
+- '11'
 macos_machine:
 - arm64-apple-darwin20.0.0
 mpi:

--- a/.ci_support/osx_arm64_mpinompipython3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpinompipython3.9.____cpython.yaml
@@ -12,6 +12,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '11'
+llvm_openmp:
+- '11'
 macos_machine:
 - arm64-apple-darwin20.0.0
 mpi:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.8.____cpython.yaml
@@ -12,6 +12,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '11'
+llvm_openmp:
+- '11'
 macos_machine:
 - arm64-apple-darwin20.0.0
 mpi:

--- a/.ci_support/osx_arm64_mpiopenmpipython3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_mpiopenmpipython3.9.____cpython.yaml
@@ -12,6 +12,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '11'
+llvm_openmp:
+- '11'
 macos_machine:
 - arm64-apple-darwin20.0.0
 mpi:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "3.3.10" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 
 # ensure mpi is defined (needed for conda-smithy recipe-lint)
@@ -45,7 +45,7 @@ requirements:
     - cmake  # [win]
     - {{ compiler('c') }}
     - {{ compiler('fortran') }}  # [not win]
-    - llvm-openmp >=4.0.1  # [osx]
+    - llvm-openmp  # [osx]
     - make      # [unix]
     - autoconf  # [unix]
     - automake  # [unix]
@@ -55,9 +55,9 @@ requirements:
     - {{ mpi }}  # [build_platform != target_platform and mpi == 'openmpi']
   host:
     - {{ mpi }}  # [mpi != 'nompi']
-    - llvm-openmp >=4.0.1  # [osx]
+    - llvm-openmp  # [osx]
   run:
-    - llvm-openmp >=4.0.1  # [osx]
+    - llvm-openmp  # [osx]
 
 test:
   requires:


### PR DESCRIPTION
This PR removes the manual version pin for `llvm-openmp` allowing `conda-forge-pinning` to take over management of that requirement. This should be ok since the current pin is way newer than the minimum version required.

This is an issue for the latest release that was originally built against llvm-openmp 12, where the conda-forge-pinning pin is 11.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
