### PR TITLE
Add patch to make SIMD instructions optional at runtime on Windows

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -5,7 +5,7 @@
 jobs:
 - job: win
   pool:
-    vmImage: windows-2019
+    vmImage: windows-2022
   strategy:
     matrix:
       win_64_:
@@ -14,6 +14,7 @@ jobs:
   timeoutInMinutes: 600
   variables:
     CONDA_BLD_PATH: D:\\bld\\
+    UPLOAD_TEMP: D:\\tmp
 
   steps:
     - task: PythonScript@0
@@ -35,7 +36,7 @@ jobs:
 
     - script: |
         call activate base
-        mamba.exe install "python=3.9" conda-build conda pip boa conda-forge-ci-setup=3 "py-lief<0.12" -c conda-forge --strict-channel-priority --yes
+        mamba.exe install "python=3.10" conda-build conda pip boa conda-forge-ci-setup=3 -c conda-forge --strict-channel-priority --yes
       displayName: Install conda-build
 
     - script: set PYTHONUNBUFFERED=1
@@ -72,6 +73,9 @@ jobs:
     - script: |
         set "GIT_BRANCH=%BUILD_SOURCEBRANCHNAME%"
         set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME:*/=%"
+        set "TEMP=$(UPLOAD_TEMP)"
+        if not exist "%TEMP%\" md "%TEMP%"
+        set "TMP=%TEMP%"
         call activate base
         upload_package --validate --feedstock-name="%FEEDSTOCK_NAME%" .\ ".\recipe" .ci_support\%CONFIG%.yaml
       displayName: Upload package

--- a/.ci_support/linux_64_mpimpich.yaml
+++ b/.ci_support/linux_64_mpimpich.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,13 +11,13 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '10'
+- '11'
 mpi:
 - mpich
 mpich:

--- a/.ci_support/linux_64_mpinompi.yaml
+++ b/.ci_support/linux_64_mpinompi.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,13 +11,13 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '10'
+- '11'
 mpi:
 - nompi
 mpich:

--- a/.ci_support/linux_64_mpiopenmpi.yaml
+++ b/.ci_support/linux_64_mpiopenmpi.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,13 +11,13 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '10'
+- '11'
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/linux_aarch64_mpimpich.yaml
+++ b/.ci_support/linux_aarch64_mpimpich.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -15,13 +15,13 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '10'
+- '11'
 mpi:
 - mpich
 mpich:

--- a/.ci_support/linux_aarch64_mpinompi.yaml
+++ b/.ci_support/linux_aarch64_mpinompi.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -15,13 +15,13 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '10'
+- '11'
 mpi:
 - nompi
 mpich:

--- a/.ci_support/linux_aarch64_mpiopenmpi.yaml
+++ b/.ci_support/linux_aarch64_mpiopenmpi.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -15,13 +15,13 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '10'
+- '11'
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/linux_ppc64le_mpimpich.yaml
+++ b/.ci_support/linux_ppc64le_mpimpich.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos7
 channel_sources:
@@ -11,13 +11,13 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '10'
+- '11'
 mpi:
 - mpich
 mpich:

--- a/.ci_support/linux_ppc64le_mpinompi.yaml
+++ b/.ci_support/linux_ppc64le_mpinompi.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos7
 channel_sources:
@@ -11,13 +11,13 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '10'
+- '11'
 mpi:
 - nompi
 mpich:

--- a/.ci_support/linux_ppc64le_mpiopenmpi.yaml
+++ b/.ci_support/linux_ppc64le_mpiopenmpi.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos7
 channel_sources:
@@ -11,13 +11,13 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '10'
+- '11'
 mpi:
 - openmpi
 mpich:

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -33,9 +33,9 @@ CONDARC
 
 
 mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -24,9 +24,9 @@ source ${MINIFORGE_HOME}/etc/profile.d/conda.sh
 conda activate base
 
 mamba install --update-specs --quiet --yes --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-About fftw-split
-================
+About fftw-split-feedstock
+==========================
+
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/fftw-feedstock/blob/main/LICENSE.txt)
 
 Home: http://fftw.org
 
 Package license: GPL-2.0-or-later
-
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/fftw-feedstock/blob/main/LICENSE.txt)
 
 Summary: The fastest Fourier transform in the west.
 

--- a/recipe/0001-cmake-Set-SIMD-flags-on-appropriate-source-files-onl.patch
+++ b/recipe/0001-cmake-Set-SIMD-flags-on-appropriate-source-files-onl.patch
@@ -1,0 +1,60 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ryan Volz <ryan.volz@gmail.com>
+Date: Thu, 6 Apr 2023 13:06:45 -0400
+Subject: [PATCH] cmake: Set SIMD flags on appropriate source files only.
+
+Doing this matches the behavior of the configure script and makefiles.
+
+Previously, enabling a set of SIMD instructions with the CMake build
+would build the whole library with that flag enabled, allowing the
+compiler to optimize by using that set of instructions anywhere. That
+would then require that any SIMD instructions enabled at build time
+would have to be present at run time. This change enables the intended
+behavior of using SIMD instructions only when they are detected at run
+time.
+---
+ CMakeLists.txt | 20 +++++++++++++++-----
+ 1 file changed, 15 insertions(+), 5 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b6e46667..aaf618ee 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -314,19 +314,29 @@ if (MSVC AND NOT (CMAKE_C_COMPILER_ID STREQUAL "Intel"))
+   target_compile_definitions (${fftw3_lib} PRIVATE /bigobj)
+ endif ()
+ if (HAVE_SSE)
+-  target_compile_options (${fftw3_lib} PRIVATE ${SSE_FLAG})
++  set_source_files_properties (${fftw_dft_simd_sse2_SOURCE}
++                               ${fftw_rdft_simd_sse2_SOURCE}
++                               PROPERTIES COMPILE_FLAGS "${SSE_FLAG}")
+ endif ()
+ if (HAVE_SSE2)
+-  target_compile_options (${fftw3_lib} PRIVATE ${SSE2_FLAG})
++  set_source_files_properties (${fftw_dft_simd_sse2_SOURCE}
++                               ${fftw_rdft_simd_sse2_SOURCE}
++                               PROPERTIES COMPILE_FLAGS "${SSE2_FLAG}")
+ endif ()
+ if (HAVE_AVX)
+-  target_compile_options (${fftw3_lib} PRIVATE ${AVX_FLAG})
++  set_source_files_properties (${fftw_dft_simd_avx_SOURCE}
++                               ${fftw_rdft_simd_avx_SOURCE}
++                               PROPERTIES COMPILE_FLAGS "${AVX_FLAG}")
+ endif ()
+ if (HAVE_AVX2)
+-  target_compile_options (${fftw3_lib} PRIVATE ${AVX2_FLAG})
++  set_source_files_properties (${fftw_dft_simd_avx2_SOURCE}
++                               ${fftw_rdft_simd_avx2_SOURCE}
++                               PROPERTIES COMPILE_FLAGS "${AVX2_FLAG}")
+ endif ()
+ if (HAVE_FMA)
+-  target_compile_options (${fftw3_lib} PRIVATE ${FMA_FLAG})
++  set_source_files_properties (${fftw_dft_simd_avx2_SOURCE}
++                               ${fftw_rdft_simd_avx2_SOURCE}
++                               PROPERTIES COMPILE_FLAGS "${FMA_FLAG}")
+ endif ()
+ if (HAVE_LIBM)
+   target_link_libraries (${fftw3_lib} m)
+-- 
+2.39.2
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "3.3.10" %}
-{% set build = 6 %}
+{% set build = 7 %}
 
 
 # ensure mpi is defined (needed for conda-smithy recipe-lint)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,8 @@ package:
 source:
   url: http://www.fftw.org/fftw-{{ version }}.tar.gz
   sha256: 56c932549852cddcfafdab3820b0200c7742675be92179e59e6215b340e26467
+  patches:
+    - 0001-cmake-Set-SIMD-flags-on-appropriate-source-files-onl.patch
 
 build:
   number: {{ build }}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* ~[ ] Reset the build number to `0` (if the version changed)~
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Over at @conda-forge/gnuradio, I've been receiving reports for a little while from Windows users who experienced crashes whenever an FFT provided by the `fftw` library was required. At first I thought it was because the builds had AVX support enabled but not SSE2, resulting in [my prior PR to fix that](https://github.com/conda-forge/fftw-feedstock/pull/91). But the reports of crashes have continued, and I think I finally have the issue fixed now with this PR.

Basically, with CMake, enabling SSE2/AVX support would cause *the entire library* to be built with those SIMD flags, resulting in SIMD instructions being inserted in the library and not gated by the check for whether the runtime CPU supported them. So users without AVX support were seeing crashes because the library hard required AVX instructions. The fix is to patch CMakeLists.txt so that enabled SIMD flags are only applied to the specific files that are intended to use them, which is exactly what is done with configure/make.

I've put in a [PR upstream](https://github.com/FFTW/fftw3/pull/322) to get the patch incorporated there, but I'm sure my [suffering users](https://github.com/ryanvolz/radioconda/issues/25) would love a fixed conda-forge package in the meantime. I've tested this with a locally rebuilt package and the crash does indeed disappear (running in a Windows VM and using the Intel Software Development Emulator to disable AVX instructions), and I've asked for users with actual hardware to test as well.