### PR TITLE
Resolves issue #94: Improved arm64 performance.

### DIFF
--- a/recipe/build_fftw.sh
+++ b/recipe/build_fftw.sh
@@ -70,8 +70,17 @@ if [[ "$target_platform" == "linux-aarch64" ]]; then
 fi
 
 if [[ "$target_platform" == "osx-arm64" ]]; then
-  ARCH_OPTS_SINGLE="--enable-neon"
-  ARCH_OPTS_DOUBLE="--enable-neon"
+  # Disable neon for now (issue # 94).  See https://github.com/FFTW/fftw3/issues/129
+  # ARCH_OPTS_SINGLE="--enable-neon --enable-armv8-cntvct-el0"
+  # ARCH_OPTS_DOUBLE="--enable-neon --enable-armv8-cntvct-el0"
+  
+  # Add cycle counter: https://www.fftw.org/fftw3_doc/Cycle-Counters.html
+  # Run ./configure --help in the fftw source dir for possible flags. 
+  ARCH_OPTS_SINGLE="--enable-armv8-cntvct-el0"
+  ARCH_OPTS_DOUBLE="--enable-armv8-cntvct-el0"
+  
+  # Disable long-double since it is the same as double on Apple Silicon
+  # https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms
   DISABLE_LONG_DOUBLE=1
 fi
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "3.3.10" %}
-{% set build = 7 %}
+{% set build = 8 %}
 
 
 # ensure mpi is defined (needed for conda-smithy recipe-lint)


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)

*(I don't know if the following are needed or not.)*

* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

Resolves issue #94 by:
* Removing `--enable-neon`: This might need to be reverted once https://github.com/FFTW/fftw3/issues/129 is resolved.
* Adding the cycle counter `--enable-armv8-cntvct-el0`.
* Enabling the long-double build (not sure why this was disabled).

